### PR TITLE
Fix meta function return types

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -48,9 +48,9 @@ export function ErrorBoundary() {
     );
 }
 
-export const meta: MetaFunction = () => ({
+export const meta: MetaFunction = () => [{
     title: "New Remix App",
-});
+}];
 
 export const links: LinksFunction = () => [
     { rel: "stylesheet", href: baseStyles },

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -9,11 +9,11 @@ export function loader({}: LoaderArgs) {
     return json({ slackTeams: getTeamSlugs(), hasOpenAIKey: !!getOpenAIKey() });
 }
 
-export const meta: MetaFunction = () => {
-    return {
+export const meta: MetaFunction = () => [
+    {
         title: `${APP_NAME}: Slack Teams`,
-    };
-};
+    },
+];
 
 export default function Index() {
     const { slackTeams, hasOpenAIKey } =

--- a/app/routes/login/$slug.tsx
+++ b/app/routes/login/$slug.tsx
@@ -86,14 +86,14 @@ export function loader({
     return json({ slug: slug });
 }
 
-export const meta: MetaFunction = () => {
-    return {
+export const meta: MetaFunction = () => [
+    {
         refresh: {
             httpEquiv: "refresh",
             content: "1",
         },
-    };
-};
+    },
+];
 
 export default function Login() {
     const { slug } = useLoaderData<LoaderData>();

--- a/app/routes/settings/index.tsx
+++ b/app/routes/settings/index.tsx
@@ -26,11 +26,11 @@ export function loader({}: LoaderArgs) {
     });
 }
 
-export const meta: MetaFunction = () => {
-    return {
+export const meta: MetaFunction = () => [
+    {
         title: `${APP_NAME}: Settings`,
-    };
-};
+    },
+];
 
 export const action = async ({ request }: ActionArgs) => {
     const formData = await request.formData();

--- a/app/routes/unread/$slug.tsx
+++ b/app/routes/unread/$slug.tsx
@@ -28,11 +28,11 @@ export function loader({ params: { slug } }: LoaderArgs) {
     });
 }
 
-export const meta: MetaFunction = ({ data }) => {
-    return {
+export const meta: MetaFunction = ({ data }) => [
+    {
         title: `${APP_NAME}: ${data.slug}`,
-    };
-};
+    },
+];
 
 export const action = async ({ request, params: { slug } }: ActionArgs) => {
     const formData = await request.formData();


### PR DESCRIPTION
## Summary
- return arrays from Remix meta functions

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_6872d56a71e48333ae92fced7d97331f