### PR TITLE
Fix dev server origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "clean": "del-cli dist desktop/build public/build",
         "dev": "npm run clean && cross-env NODE_ENV=development npm-run-all --parallel --print-label --race dev:*",
-        "dev:remix": "remix watch",
+        "dev:remix": "cross-env REMIX_DEV_ORIGIN=http://localhost:8002 remix watch",
         "dev:nodemon": "wait-on file:desktop/main.js && nodemon .",
         "dev:css": "tailwindcss -w -i ./styles/tailwind.css -o app/styles/compiledtailwind.css",
         "build": "npm run clean && npm run build:css && remix build && electron-builder",


### PR DESCRIPTION
## Summary
- fix 'Dev server origin not set' error by setting `REMIX_DEV_ORIGIN` for `remix watch`

## Testing
- `npm run build` *(fails: cannot move downloaded into final location)*

------
https://chatgpt.com/codex/tasks/task_e_6872d85219148333b356069255d1fb8c